### PR TITLE
fix uninstall issues

### DIFF
--- a/ProcessLanguageTranslatorTwigSupport.module
+++ b/ProcessLanguageTranslatorTwigSupport.module
@@ -439,8 +439,8 @@ class ProcessLanguageTranslatorTwigSupport extends ProcessLanguageTranslator imp
    */
   public function ___uninstall() {
     $p = $this->pages->get("template=admin, name=language-translator");
-    $p->status = 1045; //change status to hidden in admin > setup
-    $p->process = "ProcessLanguageTranslatorTwigSupport";
+    $p->status = 1040; //change status to hidden in admin > setup
+    $p->process = "ProcessLanguageTranslator";
     $p->save();
   }
 }


### PR DESCRIPTION
Please check...
1. in my 2.6.21dev installation the anguage-translator page status is 1040.
2. when uninstalling the page template should be reset to the original process module ProcessLanguageTranslator

kind regards,
maks
